### PR TITLE
Add calculated terrain slope and reprojection, fix oCONUS hf subsetting query

### DIFF
--- a/src/R/custom_functions.R
+++ b/src/R/custom_functions.R
@@ -7,6 +7,7 @@ source(glue("{sandbox_dir}/src/R/helper.R"))
 source(glue("{sandbox_dir}/src/R/giuh.R"))
 source(glue("{sandbox_dir}/src/R/nash_cascade.R"))
 source(glue("{sandbox_dir}/src/R/driver.R"))
+source(glue("{workflow_dir}/src_r/slope.R"))
 
 # List all functions - give access to these function to each worker
 functions_lst = c("RunDriver", "add_model_attributes", "dem_function", "twi_function", 

--- a/src/R/custom_functions.R
+++ b/src/R/custom_functions.R
@@ -7,7 +7,7 @@ source(glue("{sandbox_dir}/src/R/helper.R"))
 source(glue("{sandbox_dir}/src/R/giuh.R"))
 source(glue("{sandbox_dir}/src/R/nash_cascade.R"))
 source(glue("{sandbox_dir}/src/R/driver.R"))
-source(glue("{workflow_dir}/src_r/slope.R"))
+source(glue("{sandbox_dir}/src/R/slope.R"))
 
 # List all functions - give access to these function to each worker
 functions_lst = c("RunDriver", "add_model_attributes", "dem_function", "twi_function", 

--- a/src/R/helper.R
+++ b/src/R/helper.R
@@ -198,3 +198,39 @@ get_param <- function(input, param, default_value) {
       default_value
     })
 }
+
+reprojection_function <- function(outfile, epsg = 5070){
+  # File paths
+  gpkg_path <- outfile
+  gpkg_temp <- tempfile(fileext = ".gpkg")
+  # Get all layer names
+  sf_layers <- st_layers(gpkg_path)
+  
+  # Track first write
+  first <- TRUE
+  
+  for (layer in sf_layers$name) {
+    # Read layer
+    layer_data <- st_read(gpkg_path, layer = layer, quiet = TRUE)
+    # Reproject only if it's an sf object
+    if (inherits(layer_data, "sf")) {
+      layer_data <- st_transform(layer_data, crs = 5070)
+    }
+    # Write to new GPKG
+    st_write(
+      layer_data,
+      gpkg_temp,
+      layer = layer,
+      delete_dsn = first,
+      append = !first,
+      quiet = TRUE
+    )
+    first <- FALSE
+  }
+  
+  # Replace original GPKG
+  # file_delete(gpkg_path)
+  # file_copy(gpkg_temp, gpkg_path)
+  file.remove(gpkg_path)
+  file.copy(gpkg_temp, gpkg_path, overwrite = TRUE)
+}

--- a/src/R/main.R
+++ b/src/R/main.R
@@ -21,7 +21,8 @@
 #   STEP #5: Compute TWI and width function (inside driver.R)
 #   STEP #6: Compute GIUH (inside driver.R)
 #   STEP #7: Compute Nash cascade parameters (N and K) for surface runoff (inside driver.R)
-#   STEP #8: Append GIUH, TWI, width function, and Nash cascade parameters to model_attributes layer (inside driver.R)
+#   STEP #8: Compute terrain slope from the DEM (inside driver.R)
+#   STEP #9: Append GIUH, TWI, width function, Nash cascade parameters, and slope to model_attributes layer (inside driver.R)
 
 
 ################################ SETUP #########################################
@@ -131,6 +132,8 @@ if (use_gage_id == TRUE || use_gage_file == TRUE) {
   if (use_gage_file == TRUE) {
     d = read.csv(gage_file,colClasses = c("character")) 
     gage_ids <- d[[column_name]]
+      gage_ids <- zeroPad(gage_ids, 8)
+
   }
   
   stopifnot( length(gage_ids) > 0)

--- a/src/R/qaqc_model_attributes.R
+++ b/src/R/qaqc_model_attributes.R
@@ -337,6 +337,7 @@ for (basin in basins) {
     check_width()
     check_n_nash()
     check_k_nash()
+    check_slope()
     
   }, error = function(e) {
     # Handle error: print message and skip to the next iteration

--- a/src/R/qaqc_model_attributes.R
+++ b/src/R/qaqc_model_attributes.R
@@ -34,18 +34,18 @@ setup <-function() {
   inputs = yaml.load_file(infile_config)
 
   sandbox_dir      <<- inputs$sandbox_dir
-  output_dir        <<- inputs$output_dir
+  input_dir        <<- inputs$input_dir
   reinstall_hydrofabric <<- inputs$gpkg_model_params$reinstall_hydrofabric
   reinstall_arrow   <<- inputs$gpkg_model_params$reinstall_arrow
 
   source(paste0(sandbox_dir, "/src_r/install_load_libs.R"))
   
-  if (!file.exists(output_dir)) {
-    print(glue("Output directory does not exist, provided: {output_dir}"))
+  if (!file.exists(input_dir)) {
+    print(glue("Input directory does not exist, provided: {input_dir}"))
     return(1)
   }
   
-  setwd(output_dir)
+  setwd(input_dir)
   wbt_wd(getwd())
   
   return(0)
@@ -311,7 +311,7 @@ check_slope <- function(){
 
 # Run QA/QC Functions ---------------------------------------------------------
 # Extract the list of basins we have gpkgs for
-basins <- list.files(output_dir)
+basins <- list.files(input_dir)
 
 # Remove anything that's not numeric
 basins <- basins[str_detect(basins, "^[0-9]+$")]
@@ -327,7 +327,7 @@ failed_cats_list <- list()
 for (basin in basins) {
   tryCatch({
     # Read the geopackage -------------------
-    infile <- glue('{output_dir}/{basin}/data/gage_{basin}.gpkg')
+    infile <- glue('{input_dir}/{basin}/data/gage_{basin}.gpkg')
     # print (paste0("Reading geopackage: ", basename(infile)))
     model_attributes <- suppressWarnings(st_read(infile, layer = "divide-attributes", quiet = TRUE))
     
@@ -361,5 +361,5 @@ if (nrow(failed_df) == 0) {
   print("No basins failed QA/QC")
 } else {
   print(glue("Basins failed QA/QC: {failed_df$basin}"))
-  write.csv(failed_df, glue("{output_dir}/failed_basin_attrs.csv"), row.names = FALSE)
+  write.csv(failed_df, glue("{input_dir}/failed_basin_attrs.csv"), row.names = FALSE)
 }

--- a/src/R/qaqc_model_attributes.R
+++ b/src/R/qaqc_model_attributes.R
@@ -125,6 +125,9 @@ check_giuh <- function(){
     stop(paste0("GIUH sums are not equal to 1 in geopackage: ", infile))
   }
   
+  # Subset the sums that are < 0.99
+  fix_giuh <- sums[sums < 0.99]
+
   rm(giuh, giuh_ords, frequencies, sums)
 }
 
@@ -273,6 +276,34 @@ check_k_nash <- function(){
     failed_attrs[[length(failed_attrs) + 1]] <<- "K_nash"
     failed_reason[[length(failed_reason) + 1]] <<- "NA value(s)"
     stop(paste0("NA or NaN found in K_nash_surface in geopackage: ", infile))
+  }
+}
+
+check_slope <- function(){
+  # Does it exist?
+  if ("terrain_slope" %in% colnames(model_attributes)) {
+    slope <- model_attributes$terrain_slope
+  } else {
+    failed_cats[[length(failed_cats) + 1]] <<- paste(basin)
+    failed_attrs[[length(failed_attrs) + 1]] <<- "terrain_slope"
+    failed_reason[[length(failed_reason) + 1]] <<- "Missing"
+    stop(paste0("terrain_slope not found in geopackage: ", infile))
+  }
+  
+  # Is it NA or NaN?
+  if (any(is.na(slope)) | any(is.nan(slope))) {
+    failed_cats[[length(failed_cats) + 1]] <<- paste(basin)
+    failed_attrs[[length(failed_attrs) + 1]] <<- "terrain_slope"
+    failed_reason[[length(failed_reason) + 1]] <<- "NA value(s)"
+    stop(paste0("NA or NaN found in terrain_slope in geopackage: ", infile))
+  }
+  
+  # Check if any values are > 90
+  if (any(slope > 90)) {
+    failed_cats[[length(failed_cats) + 1]] <<- paste(basin)
+    failed_attrs[[length(failed_attrs) + 1]] <<- "terrain_slope"
+    failed_reason[[length(failed_reason) + 1]] <<- "Unreasonable value(s)"
+    stop(paste0("terrain_slope values are greater than 90 in geopackage: ", infile))
   }
 }
 

--- a/src/R/slope.R
+++ b/src/R/slope.R
@@ -1,0 +1,29 @@
+# @author Lauren Bolotin
+# @email lauren.bolotin@noaa.gov
+# @date  July 16, 2025
+
+# ########################### Slope ########################
+# Function computes slope from a DEM to replace the hydrofabric slope values
+slope_function <- function(div_infile, dem_output_dir) {
+  
+  div <- read_sf(div_infile, 'divides')
+  
+  # This was already run in twi_width.R
+  # wbt_slope(dem = glue("{dem_output_dir}/dem_corr.tif"), output = glue("{dem_output_dir}/slope.tif"),
+  #           verbose_mode = FALSE)
+  slope <- rast(glue("{dem_output_dir}/slope.tif"))
+  
+  slope_cat <- zonal::execute_zonal(data = slope,
+                                    geom = div,
+                                    ID = "divide_id",
+                                    fun = "mean")
+  print('SLOPE_CAT !!!!!!!!!!')
+  print(slope_cat)
+  # NOTE: I think this is where you could do the conversion from meters/meter to percent
+
+  return(slope_cat)
+
+  }
+  
+
+

--- a/src/R/slope.R
+++ b/src/R/slope.R
@@ -17,10 +17,6 @@ slope_function <- function(div_infile, dem_output_dir) {
                                     geom = div,
                                     ID = "divide_id",
                                     fun = "mean")
-  print('SLOPE_CAT !!!!!!!!!!')
-  print(slope_cat)
-  # NOTE: I think this is where you could do the conversion from meters/meter to percent
-
   return(slope_cat)
 
   }

--- a/src/R/tidy_hf.R
+++ b/src/R/tidy_hf.R
@@ -1,6 +1,9 @@
 #!/usr/bin/env Rscript
 
-# Example: Rscript tidy_hf.R /path/to/input_dir
+# Tidy hydrofabric gpkg files by removing disconnected divides
+# Author: Lauren Bolotin (GitHub: bolotinl) (email: lauren.bolotin@noaa.gov)
+# Date: 2025-07-10
+# Usage: Rscript tidy_hf.R /path/to/input_dir
 
 library(sf)
 library(dplyr)

--- a/src/R/tidy_hf.R
+++ b/src/R/tidy_hf.R
@@ -1,10 +1,20 @@
+#!/usr/bin/env Rscript
+
+# Example: Rscript tidy_hf.R /path/to/input_dir
+
 library(sf)
 library(dplyr)
 library(stringr)
 library(fs)
 
-# Dir where the gpkgs are that you want to check/clean. This is also where new gpkgs will be saved.
-input_dir <- "/Users/laurenbolotin/Lauren/probable-winner/ngen_delve/examples/percent_contribution"
+# Get command-line argument
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 1) {
+  stop("Usage: Rscript script_name.R /path/to/input_dir")
+}
+input_dir <- args[1]
+
+# List all GPKGs in the input directory
 gpkgs <- dir_ls(input_dir, glob = "*.gpkg")
 
 # Function to process a single gpkg
@@ -101,3 +111,9 @@ process_gpkg <- function(gpkg_path) {
 for (gpkg in gpkgs) {
   process_gpkg(gpkg)
 }
+
+# Print completion message
+cat('------------------------ \n')
+cat("All gpkgs processed.\n")
+cat('------------------------ \n')
+

--- a/src/R/tidy_hf.R
+++ b/src/R/tidy_hf.R
@@ -1,0 +1,103 @@
+library(sf)
+library(dplyr)
+library(stringr)
+library(fs)
+
+# Dir where the gpkgs are that you want to check/clean. This is also where new gpkgs will be saved.
+input_dir <- "/Users/laurenbolotin/Lauren/probable-winner/ngen_delve/examples/percent_contribution"
+gpkgs <- dir_ls(input_dir, glob = "*.gpkg")
+
+# Function to process a single gpkg
+process_gpkg <- function(gpkg_path) {
+  cat("Processing:", gpkg_path, "\n")
+  
+  # Read the 'divides' layer
+  divides <- st_read(gpkg_path, layer = "divides", quiet = TRUE)
+  divides$component_id <- -1
+  
+  # Identify disconnected groups
+  remaining <- divides
+  group_id <- 0
+  
+  while (nrow(remaining) > 0) {
+    seed <- remaining[1, ]
+    touched <- seed
+    previous_len <- -1
+    
+    while (nrow(touched) > previous_len) {
+      previous_len <- nrow(touched)
+      union_geom <- st_union(touched)
+      touched <- remaining[st_touches(remaining, union_geom, sparse = FALSE)[,1] |
+                             st_intersects(remaining, union_geom, sparse = FALSE)[,1], ]
+    }
+    
+    indices <- which(divides$divide_id %in% touched$divide_id)
+    divides$component_id[indices] <- group_id
+    remaining <- remaining[!remaining$divide_id %in% touched$divide_id, ]
+    group_id <- group_id + 1
+  }
+  
+  # Calculate component areas
+  divides$area <- st_area(divides)
+  component_areas <- divides %>%
+    group_by(component_id) %>%
+    summarise(total_area = sum(area))
+  
+  # Skip if only one component (i.e., all divides fully connected)
+  if (nrow(component_areas) == 1) {
+    cat("  No disconnected divides found. Skipping.\n\n")
+    return(NULL)
+  }
+  
+  main_component_id <- component_areas$component_id[which.max(component_areas$total_area)]
+  
+  valid_divide_ids <- divides %>%
+    filter(component_id == main_component_id) %>%
+    pull(divide_id)
+  
+  invalid_divide_ids <- divides %>%
+    filter(component_id != main_component_id) %>%
+    pull(divide_id)
+  
+  # Skip if no invalid divides found (even if you have a multipolygon, they are connected)
+  if (length(invalid_divide_ids) == 0) {
+    cat("  No disconnected divides found. Skipping.\n\n")
+    return(NULL)
+  }
+  
+  # Just get the numeric id, not the cat- or wb- prefixes
+  extract_numeric_id <- function(x) {
+    as.integer(str_extract(x, "\\d+$"))
+  }
+  
+  invalid_numeric_ids <- sapply(invalid_divide_ids, extract_numeric_id)
+  
+  # Prepare output file path
+  temp_path <- str_replace(gpkg_path, "\\.gpkg$", "_cleaned.gpkg")
+  file_copy(gpkg_path, temp_path, overwrite = TRUE)
+  
+  layers <- st_layers(gpkg_path)$name
+  
+  for (layer in layers) {
+    
+    gdf <- st_read(gpkg_path, layer = layer, quiet = TRUE)
+    
+    if (layer == "nexus") {
+      cat("     (Skipping to maintain all nexi)\n")
+    } else if ("divide_id" %in% colnames(gdf)) {
+      gdf$numeric_id <- sapply(gdf$divide_id, extract_numeric_id)
+      gdf <- gdf[!(gdf$numeric_id %in% invalid_numeric_ids), ]
+      gdf$numeric_id <- NULL
+    }
+    
+    # Write cleaned gpkg
+    st_write(gdf, temp_path, layer = layer, driver = "GPKG", delete_layer = TRUE, quiet = TRUE)
+  }
+  
+  cat("Wrote cleaned hydrofabric file:", temp_path, "\n\n")
+}
+
+# Run for all gpkgs in the input_dir
+for (gpkg in gpkgs) {
+  process_gpkg(gpkg)
+}


### PR DESCRIPTION
## Additions

- New function takes slope calculated by WhiteboxTools and adds it to a new variable in the `divide-attributes` table
- New function reprojects the final .gpkg to EPSG 5070 so they always end up in the same proj even for different NWM domains

## Changes

- For oCONUS, query hydrofabric using the `comid` associated with a flowpath instead of `hl_uri`. Note that 'comid' is technically a misnomer for oCONUS since oCONUS doesn't have NHD comids, but it still works because the values contain some other type of id from TDX-Hydro (don't know the details, but this was a tip by Justin Singh-M, and it works for the most part)

## Testing

1. Configure the `sandbox_config.yaml` to reference one of the oCONUS `hf_gpkg_path`s (e.g. `prvi_nextgen.gpkg`)
2. Change the `gage_ids` to some ids in that domain (e.g. `["50147800", "50075500", "50043800"]` 
3. Run the workflow. All catchments should pass, including the qa/qc step. 

## Screenshots
<img width="250" height="32" alt="Screenshot 2025-07-22 at 2 24 10 PM" src="https://github.com/user-attachments/assets/8bb25458-7c8f-4a6b-8901-b72e0c63a2aa" />

## Todos

- Some basins may not be indexed to `hl_link`, which is how we are now querying the hydrofabric (e.g. 15294005 in Alaska). We'll need to find an alternative method for these instances. 
