### PR TITLE
New average aspect attribute and new qaqc checks on HF .gpkg

### DIFF
--- a/src/R/aspect.R
+++ b/src/R/aspect.R
@@ -1,0 +1,25 @@
+# @author Lauren Bolotin
+# @email lauren.bolotin@noaa.gov
+# @date  Aug 25, 2025
+
+# ########################### Slope ########################
+# Function computes aspect from a DEM to replace the hydrofabric aspect values
+
+aspect_function <- function(div_infile, dem_output_dir) {
+  div <- read_sf(div_infile, 'divides')
+
+  dem <- rast(glue("{dem_output_dir}/dem.tif"))
+  aspect <- wbt_aspect(dem, glue("{dem_output_dir}/aspect.tif"))
+  aspect <- rast(glue("{dem_output_dir}/aspect.tif"))
+
+  aspect_cat <- zonal::execute_zonal(data = aspect,
+                                    geom = div,
+                                    ID = "divide_id",
+                                    fun = circular_mean)
+  
+  return(aspect_cat)
+  
+}
+
+
+

--- a/src/R/custom_functions.R
+++ b/src/R/custom_functions.R
@@ -9,9 +9,10 @@ source(glue("{sandbox_dir}/src/R/nash_cascade.R"))
 source(glue("{sandbox_dir}/src/R/veg_type.R"))
 source(glue("{sandbox_dir}/src/R/driver.R"))
 source(glue("{sandbox_dir}/src/R/slope.R"))
+source(glue("{sandbox_dir}/src/R/aspect.R"))
 
 # List all functions - give access to these function to each worker
 functions_lst = c("RunDriver", "add_model_attributes", "dem_function", "twi_function", 
                   "width_function", "twi_pre_computed_function", "giuh_function", 
                   "Nash_Cascade_Runoff", "get_nash_params", "fun_crop_lower", 
-                  "fun_crop_upper", "clean_move_dem_dir")
+                  "fun_crop_upper", "clean_move_dem_dir", "slope_function", "aspect_function")

--- a/src/R/driver.R
+++ b/src/R/driver.R
@@ -127,6 +127,8 @@ DriverGivenGPKG <- function(gage_files,
                             dem_output_dir = "",
                             dem_input_file = NULL,
                             compute_divide_attributes = FALSE,
+                            nlcd_data_path = "",
+                            calculate_vegetation = FALSE,
                             nproc = 1) {
   
   print ("DRIVER GIVEN GEOPACKAGE FUNCTION")
@@ -487,8 +489,11 @@ RunDriver <- function(gage_id = NULL,
 
   #######################. COMPUTE TERRAIN SLOPE ###########################
   # STEP #8: Take slope from the slope grid calculated in the TWI function
-
   slope <-  slope_function(div_infile = outfile, dem_output_dir = dem_output_dir)
+  
+  #######################. COMPUTE ASPECT ###########################
+  # STEP #8b: Compute aspect from the DEM 
+  aspect <-  aspect_function(div_infile = outfile, dem_output_dir = dem_output_dir)
   ####################### WRITE MODEL ATTRIBUTE FILE ###########################
   # STEP #9: Append GIUH, TWI, width function, slope, and Nash cascade N and K parameters
   # to model attributes layers
@@ -503,6 +508,7 @@ RunDriver <- function(gage_id = NULL,
 
   d_attr$K_nash_surface <- nash_params_surface$K_nash
   d_attr$terrain_slope <- slope$mean.slope
+  d_attr$terrain_aspect <- aspect$fun.aspect
   
   # Fix attribute naming issues (specific to PR hydrofabric)
   if ("mode.bexp_Time=_soil_layers_stag=1" %in% names(d_attr)) {

--- a/src/R/helper.R
+++ b/src/R/helper.R
@@ -234,3 +234,19 @@ reprojection_function <- function(outfile, epsg = 5070){
   file.remove(gpkg_path)
   file.copy(gpkg_temp, gpkg_path, overwrite = TRUE)
 }
+
+circular_mean <- function (values, coverage_fraction) {
+
+  # adopted from the 'zonal' package: https://github.com/mikejohnson51/zonal/blob/8d932f3d419489f90e7ab6c6afa085791324dc46/R/custom_function.R#L30
+  #TODO: figure out how to integrate the existing function
+  degrad = pi / 180
+
+  sinr <- sum(sin(values * degrad), na.rm = TRUE)
+
+  cosr <- sum(cos(values * degrad), na.rm = TRUE)
+
+  val = atan2(sinr, cosr) * (1 / degrad)
+
+  ifelse(val < 0, 180 + (val + 180), val)
+
+}

--- a/src/R/main.R
+++ b/src/R/main.R
@@ -23,7 +23,9 @@
 #   STEP #7: Compute Nash cascade parameters (N and K) for surface runoff (inside driver.R)
 #   STEP #8: Compute terrain slope from the DEM (inside driver.R)
 #   STEP #8a: Compute NLCD landcover (inside driver.R)
-#   STEP #9: Append GIUH, TWI, width function, Nash cascade parameters, slope, and vegetation type to model_attributes layer (inside driver.R)
+#   STEP #8b: Compute aspect from the DEM (inside driver.R)
+#   STEP #9: Append GIUH, TWI, width function, Nash cascade parameters, slope, 
+#   aspect, and vegetation type to model_attributes layer (inside driver.R)
 
 
 ################################ SETUP #########################################
@@ -50,6 +52,7 @@
 
 library(yaml)
 args <- commandArgs(trailingOnly = TRUE)
+Sys.setenv("AWS_NO_SIGN_REQUEST" = "YES")
 
 Setup <-function() {
 


### PR DESCRIPTION
New aspect attribute (the hydrofabric team warned of issues with the original values), and new ways to automatically check the quality of the HF .gpkg subsets (e.g. is drainage area as expected? are the gages indexed as needed?) Some manual checks or edge cases may still arise. 

## Additions

- New circular mean function for calculating a new mean aspect `terrain_aspect` divide-attribute
- New qa/qc check for this aspect value
- New qa/qc check on HF subset area compared to USGS metadata drainge area
- New qa/qc check on gage indexes in the flowpath-attributes table (used by ngen-cal)

## Testing

1. `python sandbox.py -subset` for any basin (e.g. `08070500`) and check in QGIS or with the qaqc script. 
